### PR TITLE
Clicking links with modifiers will not be prevented

### DIFF
--- a/src/handlePress.js
+++ b/src/handlePress.js
@@ -25,7 +25,7 @@ export default (
 
   const prevented = e.defaultPrevented
 
-  if (!target && e && !isModified(e) && e.preventDefault) {
+  if (!target && e && e.preventDefault && !isModified(e) ) {
     e.preventDefault()
   }
 

--- a/src/handlePress.js
+++ b/src/handlePress.js
@@ -25,7 +25,7 @@ export default (
 
   const prevented = e.defaultPrevented
 
-  if (!target && e && e.preventDefault) {
+  if (!target && e && !isModified(e) && e.preventDefault) {
     e.preventDefault()
   }
 

--- a/src/handlePress.js
+++ b/src/handlePress.js
@@ -25,7 +25,7 @@ export default (
 
   const prevented = e.defaultPrevented
 
-  if (!target && e && e.preventDefault && !isModified(e) ) {
+  if (!target && e && e.preventDefault && !isModified(e)) {
     e.preventDefault()
   }
 


### PR DESCRIPTION
The SyntheticLink preventDefault method is called event when the link is modified. I added a test to check if it is modified before it calls preventDefault