### PR TITLE
[NavLink] Default activeClassName to "active"

### DIFF
--- a/__tests__/NavLink.js
+++ b/__tests__/NavLink.js
@@ -110,7 +110,7 @@ it('supports custom HTML tag name', () => {
 it('supports custom HTML tag name in active mode', () => {
   const { tree, store } = createNavLink('/first', {
     to: '/first',
-    activeClassName: 'active',
+    activeClassName: 'active-foo',
     tagName: 'div'
   }) /*? $.tree */
 

--- a/__tests__/__snapshots__/NavLink.js.snap
+++ b/__tests__/__snapshots__/NavLink.js.snap
@@ -2,28 +2,37 @@
 
 exports[`EXACT: DONT show active class 1`] = `
 <a
+  aria-current={false}
+  className={undefined}
   href="/second"
   onClick={[Function]}
+  style={undefined}
 />
 `;
 
 exports[`NON-EXACT: show active class 1`] = `
 <a
+  aria-current="true"
   className="active"
   href="/first"
   onClick={[Function]}
+  style={Object {}}
 />
 `;
 
 exports[`STRICT: DONT show active class 1`] = `
 <a
+  aria-current={false}
+  className={undefined}
   href="/first/"
   onClick={[Function]}
+  style={undefined}
 />
 `;
 
 exports[`combine with existing styles and class 1`] = `
 <a
+  aria-current="true"
   className="foo active"
   href="/first"
   onClick={[Function]}
@@ -67,8 +76,11 @@ Object {
 
 exports[`isActive return false 3`] = `
 <a
+  aria-current={false}
+  className={undefined}
   href="/first"
   onClick={[Function]}
+  style={undefined}
 />
 `;
 
@@ -103,29 +115,38 @@ Object {
 
 exports[`isActive returns true 3`] = `
 <a
+  aria-current="true"
   className="active"
   href="/first"
   onClick={[Function]}
+  style={Object {}}
 />
 `;
 
 exports[`reacts to state changes (onClick) 1`] = `
 <a
+  aria-current={false}
+  className={undefined}
   href="/second/bar"
   onClick={[Function]}
+  style={undefined}
 />
 `;
 
 exports[`reacts to state changes (onClick) 2`] = `
 <a
+  aria-current="true"
   className="active"
   href="/second/bar"
   onClick={[Function]}
+  style={Object {}}
 />
 `;
 
 exports[`show activeStyle 1`] = `
 <a
+  aria-current="true"
+  className="active"
   href="/first"
   onClick={[Function]}
   style={
@@ -138,20 +159,28 @@ exports[`show activeStyle 1`] = `
 
 exports[`supports custom HTML tag name 1`] = `
 <div
+  aria-current={false}
+  className={undefined}
   onClick={[Function]}
+  style={undefined}
 />
 `;
 
 exports[`supports custom HTML tag name in active mode 1`] = `
 <div
-  className="active"
+  aria-current="true"
+  className="active-foo"
   onClick={[Function]}
+  style={Object {}}
 />
 `;
 
 exports[`supports custom HTML tag name which is still a link 1`] = `
 <a
+  aria-current={false}
+  className={undefined}
   href="somewhere"
   onClick={[Function]}
+  style={undefined}
 />
 `;

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -49,7 +49,7 @@ const NavLink = (
     pathname,
     className,
     style,
-    activeClassName,
+    activeClassName = 'active',
     activeStyle,
     exact,
     strict,

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -28,6 +28,7 @@ type OwnProps = {
   style?: Object,
   activeClassName?: string,
   activeStyle?: Object,
+  ariaCurrent?: string,
   exact?: boolean,
   strict?: boolean,
   isActive?: (?Object, Object) => boolean
@@ -51,6 +52,7 @@ const NavLink = (
     style,
     activeClassName = 'active',
     activeStyle,
+    ariaCurrent = 'true',
     exact,
     strict,
     isActive,
@@ -65,23 +67,21 @@ const NavLink = (
   const match = matchPath(pathname, { path, exact, strict })
   const active = !!(isActive ? isActive(match, location) : match)
 
-  const localClassName = active
+  const combinedClassName = active
     ? [className, activeClassName].filter(i => i).join(' ')
     : className
 
-  const localStyle = active ? { ...style, ...activeStyle } : style
+  const combinedStyle = active ? { ...style, ...activeStyle } : style
 
-  const localProps = {}
-
-  if (localClassName) {
-    localProps.className = localClassName
-  }
-
-  if (localStyle && Object.keys(localStyle).length > 0) {
-    localProps.style = localStyle
-  }
-
-  return <Link to={to} {...localProps} {...props} />
+  return (
+    <Link
+      to={to}
+      className={combinedClassName}
+      style={combinedStyle}
+      aria-current={active && ariaCurrent}
+      {...props}
+    />
+  )
 }
 
 NavLink.contextTypes = {


### PR DESCRIPTION
[NavLink] Default activeClassName to "active" like react-router's one does

See:
https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/NavLink.js#L57