### PR TITLE
feat($linkcomponent): Added support for custom component in Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   <a href="https://www.npmjs.com/package/redux-first-router-link">
     <img src="https://img.shields.io/npm/dt/redux-first-router-link.svg" alt="Downloads" />
   </a>
-  
+
   <a href="https://snyk.io/test/github/faceyspacey/redux-first-router-link">
     <img src="https://snyk.io/test/github/faceyspacey/redux-first-router-link/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/faceyspacey/redux-first-router-link">
   </a>
@@ -118,7 +118,7 @@ const { middleware, enhancer, reducer } = connectRoutes(history, {
 })
 ```
 
-But its entirely up to you. If it's easier to start to thinking in terms of paths, go for it! If that's the case, we recommend the 
+But its entirely up to you. If it's easier to start to thinking in terms of paths, go for it! If that's the case, we recommend the
 array syntax, since its easier to pass variables, eg:
 
 ```javascript
@@ -139,6 +139,7 @@ const to = `/list/${category}` // can get long & yucky with lots of variables
 * **down: boolean = false** - if `true` supplied, will trigger linking/dispatching `onMouseDown` instead of `onMouseUp`.
 * **shouldDispatch: boolean = true** - if `false` will not dispatch (useful for SEO when action handled in a parent or child element in a fancy way)
 * **target: string** - eg: `'_blank'` to open up URL in a new tab (same as standard `target` attribute to `<a>` tags)
+* **component: string | ComponentType = 'a'** - `Link` is rendered as `<a>` as a default, but you could overwrite it, for example by passing `component` as `'div'` - it will render as `<div>`, or as `CustomComponent` - it will render as `<CustomComponent>`. `CustomComponent` could be epecially useful for integration with an external UI library, like React Bootstrap (for example by providing `component={NavItem}`).
 * **...props:** - you can pass any additional props that an `<a>` tag takes, such as `className` and `style`.
 
 ## Familiar React Router Props:
@@ -149,14 +150,14 @@ const to = `/list/${category}` // can get long & yucky with lots of variables
 
 ## React Router `NavLink`-only Props
 * **activeClassName: string** - the class applied when the URL and `to` path match
-* **activeStyle: object** - the style object applied when the URL and `to` path match 
+* **activeStyle: object** - the style object applied when the URL and `to` path match
 * **exact: boolean = false** - if `true` supplied, active class/styles will not be applied in this example: URL is `/foo/bar` and link `to` is `/foo`. Whereas by default they would match.
 * **strict: boolean = false** - if there is a trailing slash in the `to` path or URL, they both must have the slash to match. If there is no slash, they must both have *no* slash.
 * **isActive: (match, location) => boolean** - a custom function to determine whether the link is active. Return `true` if active. The `match` argument is identical to React Router and not very useful. The `location` is `state.location`.
 * **ariaCurrent: string** - defaults to `'true'` when active. It's for screen-readers. Learn more [here](https://tink.uk/using-the-aria-current-attribute).
 
 ## Final Notes
-* In previous versions the `to` prop was named `href` and the `onClick` prop was name `onPress`. Those still work, but they are identical to their new names. They will be removed eventually. 
+* In previous versions the `to` prop was named `href` and the `onClick` prop was name `onPress`. Those still work, but they are identical to their new names. They will be removed eventually.
 
 * `redirect` has `replace` as an *alias* for easy migration from React Router, but the terminology in our system is `redirect`. You won't here the word `replace` much, even though that's what happens to the browser history. The reason is because server-side redirects is central to the problem solved as well, not just client-side history replacement. In general, it's a more descriptive term for how the system responds to it.
 
@@ -168,7 +169,7 @@ We use [commitizen](https://github.com/commitizen/cz-cli), so run `npm run cm` t
 
 ## Tests
 
-Reviewing a package's tests are a great way to get familiar with it. It's direct insight into the capabilities of the given package (if the tests are thorough). What's even better is a screenshot of the tests neatly organized and grouped (you know the whole "a picture says a thousand words" thing). 
+Reviewing a package's tests are a great way to get familiar with it. It's direct insight into the capabilities of the given package (if the tests are thorough). What's even better is a screenshot of the tests neatly organized and grouped (you know the whole "a picture says a thousand words" thing).
 
 Below is a screenshot of this module's tests running in [Wallaby](https://wallabyjs.com) *("An Integrated Continuous Testing Tool for JavaScript")* which everyone in the React community should be using. It's fantastic and has taken my entire workflow to the next level. It re-runs your tests on every change along with comprehensive logging, bi-directional linking to your IDE, in-line code coverage indicators, **and even snapshot comparisons + updates for Jest!** I requestsed that feature by the way :). It's basically a substitute for live-coding that inspires you to test along your journey.
 

--- a/__tests__/Link.js
+++ b/__tests__/Link.js
@@ -181,25 +181,25 @@ it('converts invalid href to "#" for path', () => {
   expect(location.type).toEqual(NOT_FOUND)
 })
 
-it('supports custom HTML tag name', () => {
+it('supports custom component as string', () => {
   const { tree, store } = createLink({
     to: 'somewhere',
-    tagName: 'div'
+    component: 'div'
   }) /*? $.tree */
 
   expect(tree).toMatchSnapshot()
 })
 
-it('supports custom HTML tag name which is still a link', () => {
+it('supports custom component which is still a link', () => {
   const { tree, store } = createLink({
     to: 'somewhere',
-    tagName: 'a'
+    component: 'a'
   }) /*? $.tree */
 
   expect(tree).toMatchSnapshot()
 })
 
-it('supports custom component', () => {
+it('supports custom component as ComponentType', () => {
   const CustomComponent = props => <span {...props} />
 
   const { tree, store } = createLink({

--- a/__tests__/Link.js
+++ b/__tests__/Link.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { NOT_FOUND } from 'redux-first-router'
 import createLink, { event } from '../__test-helpers__/createLink'
 
@@ -193,6 +194,17 @@ it('supports custom HTML tag name which is still a link', () => {
   const { tree, store } = createLink({
     to: 'somewhere',
     tagName: 'a'
+  }) /*? $.tree */
+
+  expect(tree).toMatchSnapshot()
+})
+
+it('supports custom component', () => {
+  const CustomComponent = props => <span {...props} />
+
+  const { tree, store } = createLink({
+    to: 'somewhere',
+    component: CustomComponent
   }) /*? $.tree */
 
   expect(tree).toMatchSnapshot()

--- a/__tests__/NavLink.js
+++ b/__tests__/NavLink.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { NOT_FOUND } from 'redux-first-router'
 import { createNavLink, event } from '../__test-helpers__/createLink'
 
@@ -97,30 +98,42 @@ test('isActive return false', () => {
   expect(tree).toMatchSnapshot()
 })
 
-it('supports custom HTML tag name', () => {
+it('supports custom component as string', () => {
   const { tree, store } = createNavLink('/first', {
     to: '/second',
     activeClassName: 'active',
-    tagName: 'div'
+    component: 'div'
   }) /*? $.tree */
 
   expect(tree).toMatchSnapshot()
 })
 
-it('supports custom HTML tag name in active mode', () => {
+it('supports custom component as string in active mode', () => {
   const { tree, store } = createNavLink('/first', {
     to: '/first',
     activeClassName: 'active-foo',
-    tagName: 'div'
+    component: 'div'
   }) /*? $.tree */
 
   expect(tree).toMatchSnapshot()
 })
 
-it('supports custom HTML tag name which is still a link', () => {
+it('supports custom component as ComponentType', () => {
+  const CustomComponent = props => <span {...props} />
+
+  const { tree, store } = createNavLink('/first', {
+    to: '/first',
+    activeClassName: 'active',
+    component: CustomComponent
+  }) /*? $.tree */
+
+  expect(tree).toMatchSnapshot()
+})
+
+it('supports custom component which is still a link', () => {
   const { tree, store } = createNavLink('/first', {
     to: 'somewhere',
-    tagName: 'a'
+    component: 'a'
   }) /*? $.tree */
 
   expect(tree).toMatchSnapshot()

--- a/__tests__/__snapshots__/Link.js.snap
+++ b/__tests__/__snapshots__/Link.js.snap
@@ -104,3 +104,10 @@ exports[`supports custom HTML tag name which is still a link 1`] = `
   onClick={[Function]}
 />
 `;
+
+exports[`supports custom component 1`] = `
+<span
+  href="somewhere"
+  onClick={[Function]}
+/>
+`;

--- a/__tests__/__snapshots__/Link.js.snap
+++ b/__tests__/__snapshots__/Link.js.snap
@@ -92,21 +92,21 @@ exports[`converts invalid href to "#" for path 1`] = `
 />
 `;
 
-exports[`supports custom HTML tag name 1`] = `
-<div
-  onClick={[Function]}
-/>
-`;
-
-exports[`supports custom HTML tag name which is still a link 1`] = `
-<a
+exports[`supports custom component as ComponentType 1`] = `
+<span
   href="somewhere"
   onClick={[Function]}
 />
 `;
 
-exports[`supports custom component 1`] = `
-<span
+exports[`supports custom component as string 1`] = `
+<div
+  onClick={[Function]}
+/>
+`;
+
+exports[`supports custom component which is still a link 1`] = `
+<a
   href="somewhere"
   onClick={[Function]}
 />

--- a/__tests__/__snapshots__/NavLink.js.snap
+++ b/__tests__/__snapshots__/NavLink.js.snap
@@ -167,7 +167,17 @@ exports[`show activeStyle 1`] = `
 />
 `;
 
-exports[`supports custom HTML tag name 1`] = `
+exports[`supports custom component as ComponentType 1`] = `
+<span
+  aria-current="true"
+  className="active"
+  href="/first"
+  onClick={[Function]}
+  style={Object {}}
+/>
+`;
+
+exports[`supports custom component as string 1`] = `
 <div
   aria-current={false}
   className={undefined}
@@ -176,7 +186,7 @@ exports[`supports custom HTML tag name 1`] = `
 />
 `;
 
-exports[`supports custom HTML tag name in active mode 1`] = `
+exports[`supports custom component as string in active mode 1`] = `
 <div
   aria-current="true"
   className="active-foo"
@@ -185,7 +195,7 @@ exports[`supports custom HTML tag name in active mode 1`] = `
 />
 `;
 
-exports[`supports custom HTML tag name which is still a link 1`] = `
+exports[`supports custom component which is still a link 1`] = `
 <a
   aria-current={false}
   className={undefined}

--- a/src/Link.js
+++ b/src/Link.js
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
+import type { ComponentType } from 'react'
 import { connect } from 'react-redux'
 import type { Store } from 'redux'
 import type { Connector } from 'react-redux'
@@ -20,6 +21,7 @@ type OwnProps = {
   redirect?: boolean,
   replace?: boolean,
   tagName?: string,
+  component?: ComponentType,
   children?: any, // eslint-disable-line flowtype/no-weak-types
   onPress?: OnClick,
   onClick?: OnClick,
@@ -43,6 +45,7 @@ export const Link = (
     redirect,
     replace,
     tagName = 'a',
+    component,
     children,
     onPress,
     onClick,
@@ -70,11 +73,11 @@ export const Link = (
     to,
     replace || redirect
   )
-  const Root = tagName
+  const Root = component || tagName
 
   const localProps = {}
 
-  if (tagName === 'a' && url) {
+  if ((tagName === 'a' || component) && url) {
     localProps.href = url
   }
 

--- a/src/Link.js
+++ b/src/Link.js
@@ -20,8 +20,7 @@ type OwnProps = {
   href?: To,
   redirect?: boolean,
   replace?: boolean,
-  tagName?: string,
-  component?: ComponentType,
+  component?: ComponentType | string,
   children?: any, // eslint-disable-line flowtype/no-weak-types
   onPress?: OnClick,
   onClick?: OnClick,
@@ -44,8 +43,7 @@ export const Link = (
     href,
     redirect,
     replace,
-    tagName = 'a',
-    component,
+    component = 'a',
     children,
     onPress,
     onClick,
@@ -73,11 +71,11 @@ export const Link = (
     to,
     replace || redirect
   )
-  const Root = component || tagName
+  const Root = component
 
   const localProps = {}
 
-  if ((tagName === 'a' || component) && url) {
+  if ((component === 'a' || typeof component !== 'string') && url) {
     localProps.href = url
   }
 

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import type { ComponentType } from 'react'
 import type { Store } from 'redux'
 import type { Connector } from 'react-redux'
 import matchPath from 'rudy-match-path'
@@ -18,6 +19,7 @@ type OwnProps = {
   href?: To,
   redirect?: boolean,
   replace?: boolean,
+  component?: ComponentType | string,
   children?: any,
   onPress?: OnClick,
   onClick?: OnClick,


### PR DESCRIPTION
Added `component` prop to `Link`. It allows easy integration with libraries such as `react-bootstrap`:
```javascript
import { NavItem } from 'react-bootstrap';

// ...
<NavLink to="/" component={NavItem} exact>Home</NavLink>
```
It has priority before `a` and `tagName` prop.