### PR TITLE
Fixes for SEO with basename

### DIFF
--- a/__test-helpers__/createLink.js
+++ b/__test-helpers__/createLink.js
@@ -2,7 +2,6 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { createStore, applyMiddleware, compose } from 'redux'
 import { Provider } from 'react-redux'
-import createHistory from 'history/createMemoryHistory'
 import { connectRoutes } from 'redux-first-router'
 
 import Link from '../src/Link'
@@ -17,17 +16,12 @@ const createLink = (props, initialPath, options) => {
     SECOND: '/second/:param'
   }
 
-  const history = createHistory({
+  const { middleware, enhancer, reducer } = connectRoutes(routesMap, {
     initialEntries: [initialPath || '/'],
     initialIndex: 0,
-    keyLength: 6
+    keyLength: 6,
+    ...options
   })
-
-  const { middleware, enhancer, reducer } = connectRoutes(
-    history,
-    routesMap,
-    options
-  )
 
   const middlewares = applyMiddleware(middleware)
   const enhancers = compose(enhancer, middlewares)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-first-router-link",
-  "version": "0.0.1-rudy",
+  "version": "0.0.2-rudy",
   "description": "a simple but effective <Link /> component for redux-first-router (better for SEO rather than dispatching yourself)",
   "main": "dist/index.js",
   "scripts": {
@@ -63,7 +63,7 @@
     "react-redux": "^5.x",
     "react-test-renderer": "^15.6.1",
     "redux": "^3.x",
-    "redux-first-router": "next",
+    "redux-first-router": "rudy",
     "rimraf": "^2.6.1",
     "semantic-release": "^7.0.1",
     "travis-github-status": "^1.6.3",
@@ -73,8 +73,7 @@
     "react": "*",
     "react-redux": "*",
     "redux": "*",
-    "redux-first-router": "https://github.com/faceyspacey/redux-first-router.git#rudy",
-    "rudy-history": "*"
+    "redux-first-router": "rudy"
   },
   "config": {
     "commitizen": {
@@ -91,6 +90,7 @@
   "dependencies": {
     "path-to-regexp": "^1.7.0",
     "prop-types": "15.5.10",
+    "rudy-history": "^1.0.0",
     "rudy-match-path": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "eslint-plugin-react": "^7.2.1",
     "flow-bin": "^0.52.0",
     "flow-copy-source": "^1.2.0",
-    "history": "^4.6.3",
     "husky": "^0.14.3",
     "jest": "^20.0.4",
     "lint-staged": "^4.0.3",
@@ -74,7 +73,8 @@
     "react": "*",
     "react-redux": "*",
     "redux": "*",
-    "redux-first-router": "*"
+    "redux-first-router": "https://github.com/faceyspacey/redux-first-router.git#rudy",
+    "rudy-history": "*"
   },
   "config": {
     "commitizen": {

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -6,7 +6,8 @@ import { connect } from 'react-redux'
 import type { Store } from 'redux'
 import type { Connector } from 'react-redux'
 import matchPath from 'rudy-match-path'
-import { selectLocationState } from 'redux-first-router'
+import { selectLocationState, getOptions } from 'redux-first-router'
+import { stripBasename } from 'rudy-history'
 
 import { Link } from './Link'
 import toUrl from './toUrl'
@@ -62,9 +63,18 @@ const NavLink = (
 ) => {
   to = href || to
 
+  const options = getOptions()
+  const basename = options ? options.basename || '' : ''
+
   const location = selectLocationState(store.getState())
   const path = toUrl(to, location.routesMap).split('?')[0]
-  const match = matchPath(pathname, { path, exact, strict })
+
+  const match = matchPath(pathname, {
+    path: stripBasename(path, basename),
+    exact,
+    strict
+  })
+
   const active = !!(isActive ? isActive(match, location) : match)
 
   const combinedClassName = active

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -7,7 +7,7 @@ import type { Store } from 'redux'
 import type { Connector } from 'react-redux'
 import matchPath from 'rudy-match-path'
 import { selectLocationState, getOptions } from 'redux-first-router'
-import { stripBasename } from 'rudy-history'
+import { stripBasename } from 'rudy-history/PathUtils'
 
 import { Link } from './Link'
 import toUrl from './toUrl'
@@ -64,7 +64,7 @@ const NavLink = (
   to = href || to
 
   const options = getOptions()
-  const basename = options ? options.basename || '' : ''
+  const basename = options.basename ? options.basename : ''
 
   const location = selectLocationState(store.getState())
   const path = toUrl(to, location.routesMap).split('?')[0]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5626,9 +5626,9 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
-rudy-match-path@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/rudy-match-path/-/rudy-match-path-0.1.0.tgz#5811458b234cab3502a4e548a5dedf527549a294"
+rudy-match-path@^0.3.0:
+  version "0.3.0"
+  resolved "http://0.0.0.0:4873/rudy-match-path/-/rudy-match-path-0.3.0.tgz#c90e23caac500f244d5e4ab448e2725f1254e2e8"
   dependencies:
     path-to-regexp "^1.7.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3248,16 +3248,6 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-history@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.6.3.tgz#6d723a8712c581d6bef37e8c26f4aedc6eb86967"
-  dependencies:
-    invariant "^2.2.1"
-    loose-envify "^1.2.0"
-    resolve-pathname "^2.0.0"
-    value-equal "^0.2.0"
-    warning "^3.0.0"
-
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -5370,11 +5360,12 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux-first-router@next:
-  version "0.0.2-next"
-  resolved "https://registry.yarnpkg.com/redux-first-router/-/redux-first-router-0.0.2-next.tgz#af637c0eb564245aacf056abe495fce929caf222"
+redux-first-router@rudy:
+  version "0.0.3-rudy"
+  resolved "https://registry.yarnpkg.com/redux-first-router/-/redux-first-router-0.0.3-rudy.tgz#6d478f33264201744435799a4f536442f80f03c0"
   dependencies:
-    path-to-regexp "^1.7.0"
+    rudy-history "^1.0.0"
+    rudy-match-path "^0.3.0"
 
 redux@^3.x:
   version "3.6.0"
@@ -5568,9 +5559,9 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve-pathname@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.1.0.tgz#e8358801b86b83b17560d4e3c382d7aef2100944"
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
 resolve@1.1.7:
   version "1.1.7"
@@ -5625,6 +5616,16 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
 ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
+
+rudy-history@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rudy-history/-/rudy-history-1.0.0.tgz#6e716bfea7b6dc00768a9423ace964fd0f168127"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
 
 rudy-match-path@^0.3.0:
   version "0.3.0"
@@ -6474,9 +6475,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-value-equal@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.2.1.tgz#c220a304361fce6994dbbedaa3c7e1a1b895871d"
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
Updated `redux-first-router-link#rudy`. Stripping basename, too. The original `history` removed from deps. Tests are fixed too.