### PR TITLE
fix($link): fix href not updating when route url changes

### DIFF
--- a/__test-helpers__/configureStore.js
+++ b/__test-helpers__/configureStore.js
@@ -1,0 +1,28 @@
+import { createStore, applyMiddleware, compose, combineReducers } from 'redux'
+import { connectRoutes } from 'redux-first-router'
+import thunk from 'redux-thunk'
+
+const configureStore = (initialPath, options, additionalReducers) => {
+  const routesMap = {
+    FIRST: '/first',
+    SECOND: '/second/:param'
+  }
+
+  const { middleware, enhancer, reducer } = connectRoutes(routesMap, {
+    initialEntries: [initialPath || '/'],
+    initialIndex: 0,
+    keyLength: 6,
+    ...options
+  })
+
+  const middlewares = applyMiddleware(middleware, thunk)
+  const enhancers = compose(enhancer, middlewares)
+  const rootReducer = combineReducers({
+    ...additionalReducers,
+    location: reducer
+  })
+
+  return createStore(rootReducer, enhancers)
+}
+
+export default configureStore

--- a/__test-helpers__/createLink.js
+++ b/__test-helpers__/createLink.js
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer'
 import { createStore, applyMiddleware, compose } from 'redux'
 import { Provider } from 'react-redux'
 import { connectRoutes } from 'redux-first-router'
+import thunk from 'redux-thunk'
 
 import Link from '../src/Link'
 import NavLink from '../src/NavLink'
@@ -23,7 +24,7 @@ const createLink = (props, initialPath, options) => {
     ...options
   })
 
-  const middlewares = applyMiddleware(middleware)
+  const middlewares = applyMiddleware(middleware, thunk)
   const enhancers = compose(enhancer, middlewares)
   const rootReducer = (state = {}, action = {}) => ({
     location: reducer(state.location, action)

--- a/__test-helpers__/createLink.js
+++ b/__test-helpers__/createLink.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { createStore, applyMiddleware, compose } from 'redux'
 import { Provider } from 'react-redux'
-import { connectRoutes } from 'redux-first-router'
-import thunk from 'redux-thunk'
+
+import configureStore from './configureStore'
 
 import Link from '../src/Link'
 import NavLink from '../src/NavLink'
@@ -12,25 +11,7 @@ const createLink = (props, initialPath, options) => {
   const isNavLink = !!initialPath
   const link = isNavLink ? <NavLink {...props} /> : <Link {...props} />
 
-  const routesMap = {
-    FIRST: '/first',
-    SECOND: '/second/:param'
-  }
-
-  const { middleware, enhancer, reducer } = connectRoutes(routesMap, {
-    initialEntries: [initialPath || '/'],
-    initialIndex: 0,
-    keyLength: 6,
-    ...options
-  })
-
-  const middlewares = applyMiddleware(middleware, thunk)
-  const enhancers = compose(enhancer, middlewares)
-  const rootReducer = (state = {}, action = {}) => ({
-    location: reducer(state.location, action)
-  })
-
-  const store = createStore(rootReducer, enhancers)
+  const store = configureStore(initialPath, options)
   const component = renderer.create(
     <Provider store={store}>
       {link}

--- a/__test-helpers__/createRenderCounter.js
+++ b/__test-helpers__/createRenderCounter.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Provider } from 'react-redux'
+
+import configureStore from './configureStore'
+
+const unrelated = (state = 0, { type }) =>
+  type === 'INC_UNRELATED' ? state + 1 : state
+
+const createRenderCounter = (connector, countWrapper) => {
+  const store = configureStore(undefined, undefined, { unrelated })
+
+  const RenderCounter = connector(() => {
+    ++countWrapper.count
+    return <span />
+  })
+
+  const component = renderer.create(
+    <Provider store={store}>
+      <RenderCounter />
+    </Provider>
+  )
+
+  return {
+    component,
+    store
+  }
+}
+
+export default createRenderCounter

--- a/__tests__/Link.js
+++ b/__tests__/Link.js
@@ -1,4 +1,4 @@
-import { NOT_FOUND } from 'redux-first-router'
+import { NOT_FOUND, addRoutes } from 'redux-first-router'
 import createLink, { event } from '../__test-helpers__/createLink'
 
 test('ON_CLICK: dispatches location-aware action', () => {
@@ -210,4 +210,11 @@ test('with basename options generates url with basename', () => {
   )
 
   expect(tree.props.href).toEqual('/base-foo/first')
+})
+
+test('rerenders href when route url is updated', () => {
+  const { component, store } = createLink({ to: { type: 'FIRST' } })
+  expect(component.toJSON().props.href).toEqual('/first')
+  store.dispatch(addRoutes({ FIRST: '/updatedfirst' }))
+  expect(component.toJSON().props.href).toEqual('/updatedfirst')
 })

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-test-renderer": "^15.6.1",
     "redux": "^3.x",
     "redux-first-router": "rudy",
+    "redux-thunk": "^2.2.0",
     "rimraf": "^2.6.1",
     "semantic-release": "^7.0.1",
     "travis-github-status": "^1.6.3",

--- a/src/Link.js
+++ b/src/Link.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import type { Connector } from 'react-redux'
 import { selectLocationState } from 'redux-first-router'
-import type { LocationState } from 'redux-first-router'
+import type { RoutesMap } from 'redux-first-router'
 
 import toUrl from './toUrl'
 import handlePress from './handlePress'
@@ -29,7 +29,7 @@ type OwnProps = {
 
 type Props = {
   dispatch: Function, // eslint-disable-line flowtype/no-weak-types
-  location: LocationState
+  routesMap: RoutesMap
 } & OwnProps
 
 export const UnconnectedLink = ({
@@ -45,12 +45,11 @@ export const UnconnectedLink = ({
   shouldDispatch = true,
   target,
   dispatch,
-  location,
+  routesMap,
   ...props
 }: Props) => {
   to = href || to // href is deprecated and will be removed in next major version
 
-  const { routesMap } = location
   const url = toUrl(to, routesMap)
   const handler = handlePress.bind(
     null,
@@ -91,8 +90,8 @@ export const UnconnectedLink = ({
   )
 }
 
-const mapState = state => ({ location: selectLocationState(state) })
-const connector: Connector<OwnProps, Props> = connect(mapState)
+const mapState = state => ({ routesMap: selectLocationState(state).routesMap })
+export const connector: Connector<OwnProps, Props> = connect(mapState)
 
 // $FlowIgnore
 export default connector(UnconnectedLink)

--- a/src/Link.js
+++ b/src/Link.js
@@ -1,11 +1,10 @@
 // @flow
 
 import React from 'react'
-import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import type { Store } from 'redux'
 import type { Connector } from 'react-redux'
 import { selectLocationState } from 'redux-first-router'
+import type { LocationState } from 'redux-first-router'
 
 import toUrl from './toUrl'
 import handlePress from './handlePress'
@@ -29,34 +28,28 @@ type OwnProps = {
 }
 
 type Props = {
-  dispatch: Function // eslint-disable-line flowtype/no-weak-types
+  dispatch: Function, // eslint-disable-line flowtype/no-weak-types
+  location: LocationState
 } & OwnProps
 
-type Context = {
-  store: Store<*, *>
-}
-
-export const Link = (
-  {
-    to,
-    href,
-    redirect,
-    replace,
-    tagName = 'a',
-    children,
-    onPress,
-    onClick,
-    down = false,
-    shouldDispatch = true,
-    target,
-    dispatch,
-    ...props
-  }: Props,
-  { store }: Context
-) => {
+export const UnconnectedLink = ({
+  to,
+  href,
+  redirect,
+  replace,
+  tagName = 'a',
+  children,
+  onPress,
+  onClick,
+  down = false,
+  shouldDispatch = true,
+  target,
+  dispatch,
+  location,
+  ...props
+}: Props) => {
   to = href || to // href is deprecated and will be removed in next major version
 
-  const location = selectLocationState(store.getState())
   const { routesMap } = location
   const url = toUrl(to, routesMap)
   const handler = handlePress.bind(
@@ -98,11 +91,8 @@ export const Link = (
   )
 }
 
-Link.contextTypes = {
-  store: PropTypes.object.isRequired
-}
-
-const connector: Connector<OwnProps, Props> = connect()
+const mapState = state => ({ location: selectLocationState(state) })
+const connector: Connector<OwnProps, Props> = connect(mapState)
 
 // $FlowIgnore
-export default connector(Link)
+export default connector(UnconnectedLink)

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -1,15 +1,14 @@
 // @flow
 
 import React from 'react'
-import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import type { Store } from 'redux'
 import type { Connector } from 'react-redux'
 import matchPath from 'rudy-match-path'
 import { selectLocationState, getOptions } from 'redux-first-router'
+import type { LocationState } from 'redux-first-router'
 import { stripBasename } from 'rudy-history/PathUtils'
 
-import { Link } from './Link'
+import { UnconnectedLink } from './Link'
 import toUrl from './toUrl'
 import type { To } from './toUrl'
 import type { OnClick } from './handlePress'
@@ -37,36 +36,29 @@ type OwnProps = {
 
 type Props = {
   dispatch: Function,
-  pathname: string
+  location: LocationState
 } & OwnProps
 
-type Context = {
-  store: Store<*, *>
-}
-
-const NavLink = (
-  {
-    to,
-    href,
-    pathname,
-    className,
-    style,
-    activeClassName = 'active',
-    activeStyle,
-    ariaCurrent = 'true',
-    exact,
-    strict,
-    isActive,
-    ...props
-  }: Props,
-  { store }: Context
-) => {
+const NavLink = ({
+  to,
+  href,
+  location,
+  className,
+  style,
+  activeClassName = 'active',
+  activeStyle,
+  ariaCurrent = 'true',
+  exact,
+  strict,
+  isActive,
+  ...props
+}: Props) => {
   to = href || to
 
   const options = getOptions()
   const basename = options.basename ? options.basename : ''
 
-  const location = selectLocationState(store.getState())
+  const pathname = location.pathname
   const path = toUrl(to, location.routesMap).split('?')[0]
 
   const match = matchPath(pathname, {
@@ -84,21 +76,18 @@ const NavLink = (
   const combinedStyle = active ? { ...style, ...activeStyle } : style
 
   return (
-    <Link
+    <UnconnectedLink
       to={to}
       className={combinedClassName}
       style={combinedStyle}
       aria-current={active && ariaCurrent}
+      location={location}
       {...props}
     />
   )
 }
 
-NavLink.contextTypes = {
-  store: PropTypes.object.isRequired
-}
-
-const mapState = state => ({ pathname: selectLocationState(state).pathname })
+const mapState = state => ({ location: selectLocationState(state) })
 const connector: Connector<OwnProps, Props> = connect(mapState)
 
 // $FlowIgnore

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -81,7 +81,7 @@ const NavLink = ({
       className={combinedClassName}
       style={combinedStyle}
       aria-current={active && ariaCurrent}
-      location={location}
+      routesMap={location.routesMap}
       {...props}
     />
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -5367,6 +5367,10 @@ redux-first-router@rudy:
     rudy-history "^1.0.0"
     rudy-match-path "^0.3.0"
 
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
+
 redux@^3.x:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"


### PR DESCRIPTION
Prior to this change a Link's url was set in stone at the time it rendered and never got updated
even if the route changed in the underlying store. See the new Link test for details.