### PR TITLE
Add variable storeKey

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -50,13 +50,14 @@ export const Link = (
     shouldDispatch = true,
     target,
     dispatch,
+    storeKey = 'store',
     ...props
   }: Props,
-  { store }: Context
+  context: Context
 ) => {
   to = href || to // href is deprecated and will be removed in next major version
 
-  const location = selectLocationState(store.getState())
+  const location = selectLocationState(context[storeKey].getState())
   const { routesMap } = location
   const url = toUrl(to, routesMap)
   const handler = handlePress.bind(

--- a/src/Link.js
+++ b/src/Link.js
@@ -25,7 +25,8 @@ type OwnProps = {
   onClick?: OnClick,
   down?: boolean,
   shouldDispatch?: boolean,
-  target?: string
+  target?: string,
+  storeKey?: string
 }
 
 type Props = {

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -56,13 +56,14 @@ const NavLink = (
     exact,
     strict,
     isActive,
+    storeKey = 'store',
     ...props
   }: Props,
-  { store }: Context
+  context: Context
 ) => {
   to = href || to
 
-  const location = selectLocationState(store.getState())
+  const location = selectLocationState(context[storeKey].getState())
   const path = toUrl(to, location.routesMap).split('?')[0]
   const match = matchPath(pathname, { path, exact, strict })
   const active = !!(isActive ? isActive(match, location) : match)

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -31,7 +31,8 @@ type OwnProps = {
   ariaCurrent?: string,
   exact?: boolean,
   strict?: boolean,
-  isActive?: (?Object, Object) => boolean
+  isActive?: (?Object, Object) => boolean,
+  storeKey?: string
 }
 
 type Props = {


### PR DESCRIPTION
At the moment it's not possible to add a variable `storeKey`, this was recently added to `react-redux`. Read the docs on that [here](https://github.com/reactjs/react-redux/blob/master/docs/api.md#createproviderstorekey).

To use this code you'd have to work around the default `import` a bit, at the moment I have it set up like this:

```js
// custom-store.js
export const Provider = createProvider(STORE_KEY);

export const connectExtended = (
  mapStateToProps,
  mapDispatchToProps,
  mergeProps,
  options = {}
) => {
  options.storeKey = STORE_KEY;

  return connect(
    mapStateToProps,
    mapDispatchToProps,
    mergeProps,
    options
  );
};

export { connectExtended as connect };

// component.js
import { Link } from 'redux-first-router-link/dist/Link';
import { connect as connectCustom, STORE_KEY } from './custom-store';

const ConnectedLink = connectBase()(Link);

export default () => (
  <ConnectedLink storeKey={STORE_KEY} />
);
```

It also feels a bit bulky to do all this effort just to add another `key` to the `options` from `connect`, maybe you have a better idea? And of course the `import` is ugly as hell.

Also I'm not that experienced with `flow` and there's a small problem regarding the `context` argument, I'm not sure how I can type a variable key in that object, maybe you can help me out there as well.

Thanks @faceyspacey for the great packages by the way, I'm a heavy user of `redux-first-router` and `webpack-flush-chunks` :smile_cat: