### PR TITLE
NavLink - Add a functionAsChild boolean prop to use children prop as a function

### DIFF
--- a/__test-helpers__/createLink.js
+++ b/__test-helpers__/createLink.js
@@ -32,7 +32,11 @@ const createLink = (props, initialPath) => {
   })
 
   const store = createStore(rootReducer, enhancers)
-  const component = renderer.create(<Provider store={store}>{link}</Provider>)
+  const component = renderer.create(
+    <Provider store={store}>
+      {link}
+    </Provider>
+  )
 
   return {
     component,

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -31,7 +31,8 @@ type OwnProps = {
   ariaCurrent?: string,
   exact?: boolean,
   strict?: boolean,
-  isActive?: (?Object, Object) => boolean
+  isActive?: (?Object, Object) => boolean,
+  functionAsChild?: boolean
 }
 
 type Props = {
@@ -56,6 +57,8 @@ const NavLink = (
     exact,
     strict,
     isActive,
+    children,
+    functionAsChild,
     ...props
   }: Props,
   { store }: Context
@@ -80,7 +83,9 @@ const NavLink = (
       style={combinedStyle}
       aria-current={active && ariaCurrent}
       {...props}
-    />
+    >
+      {functionAsChild ? children(active) : children}
+    </Link>
   )
 }
 

--- a/src/handlePress.js
+++ b/src/handlePress.js
@@ -4,7 +4,7 @@ import { pathToAction, redirect, getOptions } from 'redux-first-router'
 import type { RoutesMap } from 'redux-first-router'
 import type { To } from './toUrl'
 
-export type OnClick = false | ((SyntheticEvent) => ?boolean)
+export type OnClick = false | (SyntheticEvent => ?boolean)
 export default (
   url: string,
   routesMap: RoutesMap,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5626,9 +5626,9 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
-rudy-match-path@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/rudy-match-path/-/rudy-match-path-0.1.0.tgz#5811458b234cab3502a4e548a5dedf527549a294"
+rudy-match-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/rudy-match-path/-/rudy-match-path-0.3.0.tgz#c90e23caac500f244d5e4ab448e2725f1254e2e8"
   dependencies:
     path-to-regexp "^1.7.0"
 


### PR DESCRIPTION
This will allow easy conditional rendering and will integrate well with many CSS-in-JS technologies ! :)

#### Usage:

```jsx
const SuperMenu = ({classes}) => (
	<NavLink to={'/space'} functionAsChild>
		{ active => (
			<FancyButton className={active ? classes.rainbow : classes.gray}>
				 { active ? "You're in space now! Whooaaa" : 'Go to space !' }
			</FancyButton>
		)}
	</NavLink>
)
```

If there is a super fancy way to distinguish normal childs and functionsAsChilds, it would be better to use that instead of having a functionAsChild prop

But for the time being I hope this will help somebody !