### PR TITLE
NavLink - Add a functionAsChild boolean prop to use children prop as a function

### DIFF
--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -31,7 +31,8 @@ type OwnProps = {
   ariaCurrent?: string,
   exact?: boolean,
   strict?: boolean,
-  isActive?: (?Object, Object) => boolean
+  isActive?: (?Object, Object) => boolean,
+  functionAsChild?: boolean
 }
 
 type Props = {
@@ -56,6 +57,8 @@ const NavLink = (
     exact,
     strict,
     isActive,
+    children,
+    functionAsChild,
     ...props
   }: Props,
   { store }: Context
@@ -80,7 +83,9 @@ const NavLink = (
       style={combinedStyle}
       aria-current={active && ariaCurrent}
       {...props}
-    />
+    >
+      {functionAsChild ? children(active) : children}
+    </Link>
   )
 }
 


### PR DESCRIPTION
This will allow easy conditional rendering and will integrate well with many CSS-in-JS technologies ! :)

#### Usage:

```jsx
const SuperMenu = ({classes}) => (
	<NavLink to={'/space'} functionAsChild>
		{ active => (
			<FancyButton className={active ? classes.rainbow : classes.gray}>
				 { active ? "You're in space now! Whooaaa" : 'Go to space !' }
			</FancyButton>
		)}
	</NavLink>
)
```

If there is a super fancy way to distinguish normal childs and functionsAsChilds, it would be better to use that instead of having a functionAsChild prop

But for the time being I hope this will help somebody !