### PR TITLE
fix: middle mouse click in Firefox

### DIFF
--- a/src/handlePress.js
+++ b/src/handlePress.js
@@ -25,7 +25,7 @@ export default (
 
   const prevented = e.defaultPrevented
 
-  if (!target && e && e.preventDefault && !isModified(e)) {
+  if (e.button !== 1 && !target && e && e.preventDefault && !isModified(e)) {
     e.preventDefault()
   }
 


### PR DESCRIPTION
Fix middle mouse click events being prevented in Firefox

Fixes #94 