### PR TITLE
fix: use ^ for prop-types dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "path-to-regexp": "^1.7.0",
-    "prop-types": "15.5.10",
+    "prop-types": "^15.5.10",
     "rudy-match-path": "^0.3.0"
   }
 }


### PR DESCRIPTION
use `^` for `prop-types` dep. Helps flatten/clean-up `node_modules` deps