### PR TITLE
feat: legacy context usages

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -40,6 +40,7 @@ export const Link = (
   {
     to,
     href,
+    location,
     redirect,
     replace,
     tagName = 'a',
@@ -51,12 +52,10 @@ export const Link = (
     target,
     dispatch,
     ...props
-  }: Props,
-  { store }: Context
+  }: Props
 ) => {
   to = href || to // href is deprecated and will be removed in next major version
 
-  const location = selectLocationState(store.getState())
   const { routesMap } = location
   const url = toUrl(to, routesMap)
   const handler = handlePress.bind(
@@ -98,11 +97,9 @@ export const Link = (
   )
 }
 
-Link.contextTypes = {
-  store: PropTypes.object.isRequired
-}
-
-const connector: Connector<OwnProps, Props> = connect()
+const mapState = state => ({ location: selectLocationState(state) })
+const mapProps = dispatch => ({ dispatch })
+const connector: Connector<OwnProps, Props> = connect(mapState, mapProps)
 
 // $FlowIgnore
 export default connector(Link)

--- a/src/NavLink.js
+++ b/src/NavLink.js
@@ -36,19 +36,14 @@ type OwnProps = {
 }
 
 type Props = {
-  dispatch: Function,
-  pathname: string
+  dispatch: Function
 } & OwnProps
-
-type Context = {
-  store: Store<*, *>
-}
 
 const NavLink = (
   {
     to,
     href,
-    pathname,
+    location,
     className,
     style,
     activeClassName = 'active',
@@ -58,18 +53,16 @@ const NavLink = (
     strict,
     isActive,
     ...props
-  }: Props,
-  { store }: Context
+  }: Props
 ) => {
   to = href || to
 
   const options = getOptions()
   const basename = options.basename ? options.basename : ''
 
-  const location = selectLocationState(store.getState())
   const path = toUrl(to, location.routesMap).split('?')[0]
 
-  const match = matchPath(pathname, {
+  const match = matchPath(location.pathname, {
     path: stripBasename(path, basename),
     exact,
     strict
@@ -89,16 +82,13 @@ const NavLink = (
       className={combinedClassName}
       style={combinedStyle}
       aria-current={active && ariaCurrent}
+      location={location}
       {...props}
     />
   )
 }
 
-NavLink.contextTypes = {
-  store: PropTypes.object.isRequired
-}
-
-const mapState = state => ({ pathname: selectLocationState(state).pathname })
+const mapState = state => ({ location: selectLocationState(state) })
 const connector: Connector<OwnProps, Props> = connect(mapState)
 
 // $FlowIgnore


### PR DESCRIPTION
This is a raw PR to fix #101 . I did not take care of types, tests, or whatever.

You can test upgrading/downgrading from `react-redux@v5.1.0` / to `react-redux@v6.0.0` with the `redux-first-router` branch of [this repository](https://github.com/cdoublev/react-redux-v6) as a simple boilerplate and run `npm run start:client` or `npm run start:dev` or `npm run start`.