### PR TITLE
fix(hash): Ensure hash is included when using hash history

### DIFF
--- a/__tests__/Link.js
+++ b/__tests__/Link.js
@@ -1,213 +1,260 @@
-import { NOT_FOUND } from 'redux-first-router'
-import createLink, { event } from '../__test-helpers__/createLink'
+import { NOT_FOUND } from "redux-first-router";
+import { createHashHistory } from "rudy-history";
+import createLink, { event } from "../__test-helpers__/createLink";
 
-test('ON_CLICK: dispatches location-aware action', () => {
+test("ON_CLICK: dispatches location-aware action", () => {
   const { tree, store } = createLink({
-    to: '/first',
-    children: 'CLICK ME'
-  }) /*? $.tree */
+    to: "/first",
+    children: "CLICK ME"
+  }); /*? $.tree */
 
-  expect(tree).toMatchSnapshot() /*? store.getState() */
+  expect(tree).toMatchSnapshot(); /*? store.getState() */
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
+  const { location } = store.getState(); /*? $.location */
 
-  expect(location.pathname).toEqual('/first')
-  expect(location.type).toEqual('FIRST')
-})
+  expect(location.pathname).toEqual("/first");
+  expect(location.type).toEqual("FIRST");
+});
 
-it('ON_CLICK: does NOT dispatch if shouldDispatch === false', () => {
-  const { tree, store } = createLink({ to: '/first', shouldDispatch: false })
+it("ON_CLICK: does NOT dispatch if shouldDispatch === false", () => {
+  const { tree, store } = createLink({ to: "/first", shouldDispatch: false });
 
-  expect(tree).toMatchSnapshot()
+  expect(tree).toMatchSnapshot();
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
+  const { location } = store.getState(); /*? $.location */
 
-  expect(location.pathname).not.toEqual('/first')
-  expect(location.type).not.toEqual('FIRST')
-  expect(location.pathname).toEqual('/')
-})
+  expect(location.pathname).not.toEqual("/first");
+  expect(location.type).not.toEqual("FIRST");
+  expect(location.pathname).toEqual("/");
+});
 
-it('ON_CLICK: does NOT dispatch if onClick returns false', () => {
-  const { tree, store } = createLink({ to: '/first', onClick: () => false })
+it("ON_CLICK: does NOT dispatch if onClick returns false", () => {
+  const { tree, store } = createLink({ to: "/first", onClick: () => false });
 
-  expect(tree).toMatchSnapshot()
+  expect(tree).toMatchSnapshot();
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
+  const { location } = store.getState(); /*? $.location */
 
-  expect(location.pathname).not.toEqual('/first')
-  expect(location.type).not.toEqual('FIRST')
-  expect(location.pathname).toEqual('/')
-})
+  expect(location.pathname).not.toEqual("/first");
+  expect(location.type).not.toEqual("FIRST");
+  expect(location.pathname).toEqual("/");
+});
 
-it('ON_CLICK: DOES dispatch if onClick returns true', () => {
-  const { tree, store } = createLink({ to: '/first', onClick: () => true })
+it("ON_CLICK: DOES dispatch if onClick returns true", () => {
+  const { tree, store } = createLink({ to: "/first", onClick: () => true });
 
-  expect(tree).toMatchSnapshot()
+  expect(tree).toMatchSnapshot();
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
+  const { location } = store.getState(); /*? $.location */
 
-  expect(location.pathname).toEqual('/first')
-  expect(location.type).toEqual('FIRST')
-})
+  expect(location.pathname).toEqual("/first");
+  expect(location.type).toEqual("FIRST");
+});
 
-it('ON_CLICK: DOES dispatch if onClick returns undefined', () => {
+it("ON_CLICK: DOES dispatch if onClick returns undefined", () => {
   const { tree, store } = createLink({
-    to: '/first',
+    to: "/first",
     onClick: () => undefined
-  })
+  });
 
-  expect(tree).toMatchSnapshot()
+  expect(tree).toMatchSnapshot();
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
+  const { location } = store.getState(); /*? $.location */
 
-  expect(location.pathname).toEqual('/first')
-  expect(location.type).toEqual('FIRST')
-})
+  expect(location.pathname).toEqual("/first");
+  expect(location.type).toEqual("FIRST");
+});
 
-it('ON_MOUSE_DOWN: dispatches action onMouseDown if down === true', () => {
+it("ON_MOUSE_DOWN: dispatches action onMouseDown if down === true", () => {
   const { tree, store } = createLink({
-    to: '/first',
+    to: "/first",
     down: true
-  }) /*? $.tree */
+  }); /*? $.tree */
 
-  expect(tree).toMatchSnapshot()
+  expect(tree).toMatchSnapshot();
 
-  tree.props.onClick(event) // e.preventDefault() called and nothing dispatched + linking prevented
+  tree.props.onClick(event); // e.preventDefault() called and nothing dispatched + linking prevented
 
-  let { location } = store.getState()
-  expect(location.pathname).toEqual('/')
+  let { location } = store.getState();
+  expect(location.pathname).toEqual("/");
 
-  tree.props.onMouseDown(event)
+  tree.props.onMouseDown(event);
 
-  location = store.getState().location /*? */
+  location = store.getState().location; /*? */
 
-  expect(location.pathname).toEqual('/first')
-  expect(location.type).toEqual('FIRST')
-})
+  expect(location.pathname).toEqual("/first");
+  expect(location.type).toEqual("FIRST");
+});
 
-it('ON_CLICK: dispatches redirect if redirect === true', () => {
+it("ON_CLICK: dispatches redirect if redirect === true", () => {
   const { tree, store } = createLink({
-    to: '/first',
-    children: 'CLICK ME',
+    to: "/first",
+    children: "CLICK ME",
     redirect: true
-  }) /*? $.tree */
+  }); /*? $.tree */
 
-  expect(tree).toMatchSnapshot() /*? store.getState() */
+  expect(tree).toMatchSnapshot(); /*? store.getState() */
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
+  const { location } = store.getState(); /*? $.location */
 
-  expect(location.pathname).toEqual('/first')
-  expect(location.kind).toEqual('redirect')
-})
+  expect(location.pathname).toEqual("/first");
+  expect(location.kind).toEqual("redirect");
+});
 
-it('ON_TOUCH_START: dispatches action onTouchStart if down === true', () => {
+it("ON_TOUCH_START: dispatches action onTouchStart if down === true", () => {
   const { tree, store } = createLink({
-    to: '/first',
+    to: "/first",
     down: true
-  }) /*? $.tree */
+  }); /*? $.tree */
 
-  expect(tree).toMatchSnapshot()
+  expect(tree).toMatchSnapshot();
 
-  tree.props.onTouchStart(event)
+  tree.props.onTouchStart(event);
 
-  const { location } = store.getState() /*? $.location */
+  const { location } = store.getState(); /*? $.location */
 
-  expect(location.pathname).toEqual('/first')
-  expect(location.type).toEqual('FIRST')
-})
+  expect(location.pathname).toEqual("/first");
+  expect(location.type).toEqual("FIRST");
+});
 
-it('converts href as array of strings to path', () => {
-  const { tree, store } = createLink({ to: ['second', 'bar'] }) /*? $.tree */
+it("converts href as array of strings to path", () => {
+  const { tree, store } = createLink({ to: ["second", "bar"] }); /*? $.tree */
 
-  expect(tree).toMatchSnapshot() /*? store.getState() */
+  expect(tree).toMatchSnapshot(); /*? store.getState() */
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
+  const { location } = store.getState(); /*? $.location */
 
-  expect(location.pathname).toEqual('/second/bar')
-  expect(location.type).toEqual('SECOND')
-})
+  expect(location.pathname).toEqual("/second/bar");
+  expect(location.type).toEqual("SECOND");
+});
 
-it('converts href as action object to path', () => {
-  const action = { type: 'SECOND', payload: { param: 'bar' } }
-  const { tree, store } = createLink({ to: action }) /*? $.tree */
+it("converts href as action object to path", () => {
+  const action = { type: "SECOND", payload: { param: "bar" } };
+  const { tree, store } = createLink({ to: action }); /*? $.tree */
 
-  expect(tree).toMatchSnapshot() /*? store.getState() */
+  expect(tree).toMatchSnapshot(); /*? store.getState() */
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
+  const { location } = store.getState(); /*? $.location */
 
-  expect(location.pathname).toEqual('/second/bar')
-  expect(location.type).toEqual('SECOND')
-})
+  expect(location.pathname).toEqual("/second/bar");
+  expect(location.type).toEqual("SECOND");
+});
 
 it('converts href as non-matched action object to "#" for path', () => {
-  const action = { type: 'MISSED' }
-  const { tree, store } = createLink({ to: action }) /*? $.tree */
+  const action = { type: "MISSED" };
+  const { tree, store } = createLink({ to: action }); /*? $.tree */
 
-  expect(tree.props.href).toEqual('#')
-  expect(tree).toMatchSnapshot()
+  expect(tree.props.href).toEqual("#");
+  expect(tree).toMatchSnapshot();
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
-  expect(location.type).toEqual(NOT_FOUND)
-})
+  const { location } = store.getState(); /*? $.location */
+  expect(location.type).toEqual(NOT_FOUND);
+});
 
 it('converts invalid href to "#" for path', () => {
-  const { tree, store } = createLink({ to: '' }) /*? $.tree */
+  const { tree, store } = createLink({ to: "" }); /*? $.tree */
 
-  expect(tree.props.href).toEqual('#')
-  expect(tree).toMatchSnapshot()
+  expect(tree.props.href).toEqual("#");
+  expect(tree).toMatchSnapshot();
 
-  tree.props.onClick(event)
+  tree.props.onClick(event);
 
-  const { location } = store.getState() /*? $.location */
-  expect(location.type).toEqual(NOT_FOUND)
-})
+  const { location } = store.getState(); /*? $.location */
+  expect(location.type).toEqual(NOT_FOUND);
+});
 
-it('supports custom HTML tag name', () => {
+it("supports custom HTML tag name", () => {
   const { tree, store } = createLink({
-    to: 'somewhere',
-    tagName: 'div'
-  }) /*? $.tree */
+    to: "somewhere",
+    tagName: "div"
+  }); /*? $.tree */
 
-  expect(tree).toMatchSnapshot()
-})
+  expect(tree).toMatchSnapshot();
+});
 
-it('supports custom HTML tag name which is still a link', () => {
+it("supports custom HTML tag name which is still a link", () => {
   const { tree, store } = createLink({
-    to: 'somewhere',
-    tagName: 'a'
-  }) /*? $.tree */
+    to: "somewhere",
+    tagName: "a"
+  }); /*? $.tree */
 
-  expect(tree).toMatchSnapshot()
-})
+  expect(tree).toMatchSnapshot();
+});
 
-test('with basename options generates url with basename', () => {
-  const options = { basename: '/base-foo' }
+test("with basename options generates url with basename", () => {
+  const options = { basename: "/base-foo" };
   const { tree, store } = createLink(
     {
-      to: '/first',
-      children: 'CLICK ME'
+      to: "/first",
+      children: "CLICK ME"
     },
-    '/',
+    "/",
     options
-  )
+  );
 
-  expect(tree.props.href).toEqual('/base-foo/first')
-})
+  expect(tree.props.href).toEqual("/base-foo/first");
+});
+
+test("with hash history", () => {
+  const options = { createHistory: createHashHistory };
+  const to = "/first";
+  const { tree, store } = createLink(
+    {
+      to,
+      children: "CLICK ME"
+    },
+    null,
+    options
+  );
+  expect(tree).toMatchSnapshot();
+
+  tree.props.onClick(event);
+
+  const { location } = store.getState(); /*? $.location */
+
+  expect(tree.props.href).toEqual("#/first");
+  expect(location.pathname).toEqual("/first");
+  expect(location.type).toEqual("FIRST");
+});
+
+test("with hash history and with basename", () => {
+  const options = { createHistory: createHashHistory, basename: "/base-foo" };
+  const to = "/first";
+  window.location.hash = "#/base-foo";
+  const { tree, store } = createLink(
+    {
+      to,
+      children: "CLICK ME"
+    },
+    null,
+    options
+  );
+
+  expect(tree).toMatchSnapshot();
+
+  tree.props.onClick(event);
+
+  const { location } = store.getState(); /*? $.location */
+
+  expect(tree.props.href).toEqual("#/base-foo/first");
+  expect(location.pathname).toEqual("/first");
+  expect(location.type).toEqual("FIRST");
+});

--- a/__tests__/__snapshots__/Link.js.snap
+++ b/__tests__/__snapshots__/Link.js.snap
@@ -104,3 +104,21 @@ exports[`supports custom HTML tag name which is still a link 1`] = `
   onClick={[Function]}
 />
 `;
+
+exports[`with hash history 1`] = `
+<a
+  href="#/first"
+  onClick={[Function]}
+>
+  CLICK ME
+</a>
+`;
+
+exports[`with hash history and with basename 1`] = `
+<a
+  href="#/base-foo/first"
+  onClick={[Function]}
+>
+  CLICK ME
+</a>
+`;

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "redux": "^3.x",
     "redux-first-router": "^2.1.1",
     "rimraf": "^2.6.1",
+    "rudy-history": "^1.0.0",
     "semantic-release": "^15.12.4",
     "travis-github-status": "^1.6.3",
     "webpack": "3.5.5"
@@ -93,7 +94,6 @@
   "dependencies": {
     "path-to-regexp": "^1.7.0",
     "prop-types": "15.5.10",
-    "rudy-history": "^1.0.0",
     "rudy-match-path": "^0.3.0"
   }
 }

--- a/src/handlePress.js
+++ b/src/handlePress.js
@@ -1,10 +1,15 @@
 // @flow
 
-import { pathToAction, redirect, getOptions } from 'redux-first-router'
-import type { RoutesMap } from 'redux-first-router'
-import type { To } from './toUrl'
+import {
+  pathToAction,
+  redirect,
+  getOptions,
+  history
+} from "redux-first-router";
+import type { RoutesMap } from "redux-first-router";
+import type { To } from "./toUrl";
 
-export type OnClick = false | ((SyntheticEvent) => ?boolean)
+export type OnClick = false | (SyntheticEvent => ?boolean);
 export default (
   url: string,
   routesMap: RoutesMap,
@@ -16,17 +21,17 @@ export default (
   dispatchRedirect?: boolean,
   e: SyntheticEvent
 ) => {
-  let shouldGo = true
+  let shouldGo = true;
 
   if (onClick) {
-    shouldGo = onClick(e) // onClick can return false to prevent dispatch
-    shouldGo = typeof shouldGo === 'undefined' ? true : shouldGo
+    shouldGo = onClick(e); // onClick can return false to prevent dispatch
+    shouldGo = typeof shouldGo === "undefined" ? true : shouldGo;
   }
 
-  const prevented = e.defaultPrevented
+  const prevented = e.defaultPrevented;
 
   if (!target && e && e.preventDefault && !isModified(e)) {
-    e.preventDefault()
+    e.preventDefault();
   }
 
   if (
@@ -37,14 +42,24 @@ export default (
     e.button === 0 &&
     !isModified(e)
   ) {
-    const { querySerializer: serializer } = getOptions()
-    let action = isAction(to) ? to : pathToAction(url, routesMap, serializer)
-    action = dispatchRedirect ? redirect(action) : action
-    dispatch(action)
-  }
-}
+    const { querySerializer: serializer } = getOptions();
+    let action = to;
 
-const isAction = (to: ?To) => typeof to === 'object' && !Array.isArray(to)
+    if (!isAction(to)) {
+      url =
+        url.indexOf("#") > -1
+          ? url.substring(url.indexOf("#") + 1, url.length)
+          : url;
+
+      action = pathToAction(url, routesMap, serializer);
+    }
+
+    action = dispatchRedirect ? redirect(action) : action;
+    dispatch(action);
+  }
+};
+
+const isAction = (to: ?To) => typeof to === "object" && !Array.isArray(to);
 
 const isModified = (e: Object) =>
-  !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey)
+  !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey);

--- a/src/toUrl.js
+++ b/src/toUrl.js
@@ -1,46 +1,50 @@
 // @flow
 
-import { actionToPath, getOptions } from 'redux-first-router'
-import type { RoutesMap } from 'redux-first-router'
+import { actionToPath, getOptions, history } from "redux-first-router";
+import type { RoutesMap } from "redux-first-router";
 
-export type To = string | Array<string> | Object
+export type To = string | Array<string> | Object;
 
 export default (to?: ?To, routesMap: RoutesMap): string => {
-  const { querySerializer, basename } = getOptions()
+  const { querySerializer, basename } = getOptions();
 
-  if (to && typeof to === 'string') {
-    return basename ? basename + to : to
-  }
-  else if (Array.isArray(to)) {
-    const path = `/${to.join('/')}`
-    return basename ? basename + path : path
-  }
-  else if (typeof to === 'object') {
-    const action = to
+  if (to && typeof to === "string") {
+    return history().createHref({
+      pathname: to
+    });
+  } else if (Array.isArray(to)) {
+    const path = `/${to.join("/")}`;
+    return history().createHref({
+      pathname: path
+    });
+  } else if (typeof to === "object") {
+    const action = to;
 
     try {
-      const path = actionToPath(action, routesMap, querySerializer)
-      return basename ? basename + path : path
-    }
-    catch (e) {
-      if (process.env.NODE_ENV === 'development') {
+      const path = actionToPath(action, routesMap, querySerializer);
+
+      return history().createHref({
+        pathname: path
+      });
+    } catch (e) {
+      if (process.env.NODE_ENV === "development") {
         console.warn(
-          '[redux-first-router-link] could not create path from action:',
+          "[redux-first-router-link] could not create path from action:",
           action,
-          'For reference, here are your current routes:',
+          "For reference, here are your current routes:",
           routesMap
-        )
+        );
       }
 
-      return '#'
+      return "#";
     }
   }
 
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV === "development") {
     console.warn(
-      '[redux-first-router-link] `to` prop must be a string, array or action object. You provided:',
+      "[redux-first-router-link] `to` prop must be a string, array or action object. You provided:",
       to
-    )
+    );
   }
-  return '#'
-}
+  return "#";
+};


### PR DESCRIPTION
Changed so src/toUrl.js are now using history to create the href. In src/handlePress.js we remove
the hash if it exists when creating an action with the url, this to find the right route.