### PR TITLE
fix(hash): Ensure hash is included when using hash history

### DIFF
--- a/__test-helpers__/createLink.js
+++ b/__test-helpers__/createLink.js
@@ -24,17 +24,16 @@ const createLink = (props, initialPath, options) => {
   })
 
   const middlewares = applyMiddleware(middleware)
-  const enhancers = compose(enhancer, middlewares)
+  const enhancers = compose(
+    enhancer,
+    middlewares
+  )
   const rootReducer = (state = {}, action = {}) => ({
     location: reducer(state.location, action)
   })
 
   const store = createStore(rootReducer, enhancers)
-  const component = renderer.create(
-    <Provider store={store}>
-      {link}
-    </Provider>
-  )
+  const component = renderer.create(<Provider store={store}>{link}</Provider>)
 
   return {
     component,

--- a/__tests__/Link.js
+++ b/__tests__/Link.js
@@ -1,4 +1,5 @@
 import { NOT_FOUND } from 'redux-first-router'
+import { createHashHistory } from 'rudy-history'
 import createLink, { event } from '../__test-helpers__/createLink'
 
 test('ON_CLICK: dispatches location-aware action', () => {
@@ -210,4 +211,50 @@ test('with basename options generates url with basename', () => {
   )
 
   expect(tree.props.href).toEqual('/base-foo/first')
+})
+
+test('with hash history', () => {
+  const options = { createHistory: createHashHistory }
+  const to = '/first'
+  const { tree, store } = createLink(
+    {
+      to,
+      children: 'CLICK ME'
+    },
+    null,
+    options
+  )
+  expect(tree).toMatchSnapshot()
+
+  tree.props.onClick(event)
+
+  const { location } = store.getState() /*? $.location */
+
+  expect(tree.props.href).toEqual('#/first')
+  expect(location.pathname).toEqual('/first')
+  expect(location.type).toEqual('FIRST')
+})
+
+test('with hash history and with basename', () => {
+  const options = { createHistory: createHashHistory, basename: '/base-foo' }
+  const to = '/first'
+  window.location.hash = '#/base-foo'
+  const { tree, store } = createLink(
+    {
+      to,
+      children: 'CLICK ME'
+    },
+    null,
+    options
+  )
+
+  expect(tree).toMatchSnapshot()
+
+  tree.props.onClick(event)
+
+  const { location } = store.getState() /*? $.location */
+
+  expect(tree.props.href).toEqual('#/base-foo/first')
+  expect(location.pathname).toEqual('/first')
+  expect(location.type).toEqual('FIRST')
 })

--- a/__tests__/__snapshots__/Link.js.snap
+++ b/__tests__/__snapshots__/Link.js.snap
@@ -104,3 +104,21 @@ exports[`supports custom HTML tag name which is still a link 1`] = `
   onClick={[Function]}
 />
 `;
+
+exports[`with hash history 1`] = `
+<a
+  href="#/first"
+  onClick={[Function]}
+>
+  CLICK ME
+</a>
+`;
+
+exports[`with hash history and with basename 1`] = `
+<a
+  href="#/base-foo/first"
+  onClick={[Function]}
+>
+  CLICK ME
+</a>
+`;

--- a/src/handlePress.js
+++ b/src/handlePress.js
@@ -1,10 +1,10 @@
 // @flow
 
-import { pathToAction, redirect, getOptions } from 'redux-first-router'
+import { pathToAction, redirect, getOptions, history } from 'redux-first-router'
 import type { RoutesMap } from 'redux-first-router'
 import type { To } from './toUrl'
 
-export type OnClick = false | ((SyntheticEvent) => ?boolean)
+export type OnClick = false | (SyntheticEvent => ?boolean)
 export default (
   url: string,
   routesMap: RoutesMap,
@@ -38,7 +38,17 @@ export default (
     !isModified(e)
   ) {
     const { querySerializer: serializer } = getOptions()
-    let action = isAction(to) ? to : pathToAction(url, routesMap, serializer)
+    let action = to
+
+    if (!isAction(to)) {
+      url =
+        url.indexOf('#') > -1
+          ? url.substring(url.indexOf('#') + 1, url.length)
+          : url
+
+      action = pathToAction(url, routesMap, serializer)
+    }
+
     action = dispatchRedirect ? redirect(action) : action
     dispatch(action)
   }

--- a/src/toUrl.js
+++ b/src/toUrl.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { actionToPath, getOptions } from 'redux-first-router'
+import { actionToPath, getOptions, history } from 'redux-first-router'
 import type { RoutesMap } from 'redux-first-router'
 
 export type To = string | Array<string> | Object
@@ -9,20 +9,24 @@ export default (to?: ?To, routesMap: RoutesMap): string => {
   const { querySerializer, basename } = getOptions()
 
   if (to && typeof to === 'string') {
-    return basename ? basename + to : to
-  }
-  else if (Array.isArray(to)) {
+    return history().createHref({
+      pathname: to
+    })
+  } else if (Array.isArray(to)) {
     const path = `/${to.join('/')}`
-    return basename ? basename + path : path
-  }
-  else if (typeof to === 'object') {
+    return history().createHref({
+      pathname: path
+    })
+  } else if (typeof to === 'object') {
     const action = to
 
     try {
       const path = actionToPath(action, routesMap, querySerializer)
-      return basename ? basename + path : path
-    }
-    catch (e) {
+
+      return history().createHref({
+        pathname: path
+      })
+    } catch (e) {
       if (process.env.NODE_ENV === 'development') {
         console.warn(
           '[redux-first-router-link] could not create path from action:',


### PR DESCRIPTION
Changed so src/toUrl.js are now using history to create the href. In src/handlePress.js we remove
the hash if it exists when creating an action with the url, this to find the right route.

Sorry for all the PR:s that I closed hehe.